### PR TITLE
Fix to NTD2D_SANITIZED_REF_NAME

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -172,7 +172,7 @@ runs:
     - uses: actions/upload-artifact@v3
       name: Upload Documentation Artifacts
       with:
-        name: ${{ github.event.repository.name }}-${{ env.NTD2D_SANITIZED_REF_NAME }}-${{ github.sha }}
+        name: ${{ github.event.repository.name }}-${{ env.SANITIZED_REF_NAME }}-${{ github.sha }}
         path: |
           ${{ steps.ntd2d.outputs.borged-build-folder }}/latex/${{ github.event.repository.name }}.pdf
           ${{ steps.ntd2d.outputs.borged-build-folder }}/latex/${{ github.event.repository.name }}.log


### PR DESCRIPTION
Without this, two zip files are generated, one for PDF and the other for epub and html. I don't think this is intended behavior