### PR TITLE
Unhide toctree entries

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ this workflow.
 .. toctree::
    :maxdepth: 1
    :caption: Contents:
+   :hidden:
 
    customization
    QandA
@@ -54,6 +55,7 @@ this workflow.
 .. toctree::
    :maxdepth: 1
    :caption: Actions:
+   :hidden:
 
    docs4nist
    ntd2d


### PR DESCRIPTION
Currently impossible to navigate to many places in the docs, e.g., [Customization](https://pages.nist.gov/Docs4NIST/en/latest/customization.html)